### PR TITLE
Add HttpClient provider and fix tests

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,6 +4,7 @@ import { routes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideNativeDateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
 import { MY_DATE_FORMATS } from './app-date-formats';
+import { provideHttpClient } from '@angular/common/http';
 
 // 👇 Registrar el idioma español
 import { registerLocaleData } from '@angular/common';
@@ -16,6 +17,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAnimationsAsync(),
+    provideHttpClient(),
 
     provideNativeDateAdapter(), // ✅ Usa el adaptador de fechas nativo
 

--- a/src/app/generos/generos.component.spec.ts
+++ b/src/app/generos/generos.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { GenerosComponent } from './generos.component';
 
@@ -8,7 +9,7 @@ describe('GenerosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GenerosComponent]
+      imports: [GenerosComponent, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/generos/generos.service.spec.ts
+++ b/src/app/generos/generos.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { GenerosService } from './generos.service';
 
@@ -6,7 +7,9 @@ describe('GenerosService', () => {
   let service: GenerosService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(GenerosService);
   });
 


### PR DESCRIPTION
## Summary
- provide `HttpClient` in the application config
- include `HttpClientTestingModule` in genero service test
- include `HttpClientTestingModule` in genero component test

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e13f588083328dccf1db14d6c906